### PR TITLE
pytest: fix to 9.0.1

### DIFF
--- a/requirements/requirements.python.test.txt
+++ b/requirements/requirements.python.test.txt
@@ -1,2 +1,2 @@
-pytest
+pytest==9.0.1
 pytest_console_scripts


### PR DESCRIPTION
Deliberately the version below the current latest (9.0.2).